### PR TITLE
ci: support latex math mode ($)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ doc =
     Sphinx==3.2.1
     sphinx-book-theme==0.0.36
     sphinx-copybutton==0.3.0
+    sphinx-math-dollar==1.2
     sphinx-togglebutton==0.2.2
     sphinxcontrib-bibtex==1.0.0
 dev =

--- a/src/conf.py
+++ b/src/conf.py
@@ -27,9 +27,16 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx_copybutton",
+    "sphinx_math_dollar",
     "sphinx_togglebutton",
     "sphinxcontrib.bibtex",
 ]
+mathjax_config = {
+    "tex2jax": {
+        "inlineMath": [["\\(", "\\)"]],
+        "displayMath": [["\\[", "\\]"]],
+    },
+}
 
 exclude_patterns = [
     ".DS_Store",

--- a/src/theory/data.rst
+++ b/src/theory/data.rst
@@ -24,17 +24,17 @@ PWA data
 Comparison with Measurements
 ----------------------------
 
-Luminosity :math:`L`
+Luminosity $L$
 
-Measurements :math:`N`
+Measurements $N$
 
-Cross section :math:`\sigma`
+Cross section $\sigma$
 
 .. math::
 
   \frac{dN}{d\Phi_f} = L \cdot \frac{d\sigma}{d\Phi_f}
 
-Number of events in a infinitesimal phase space element :math:`\Phi_f` is
+Number of events in a infinitesimal phase space element $\Phi_f$ is
 proportional to the cross section of a initial state transitioning to the final
 state in the infinitesimal phase space element.
 

--- a/src/theory/dynamics.rst
+++ b/src/theory/dynamics.rst
@@ -4,14 +4,14 @@ Dynamics
 .. warning::
   These pages and are **under development**.
 
-:math:`K`-matrix
-----------------
+$K$-matrix
+----------
 
 - Introduce with references to :ref:`theory/introduction:Transition amplitude`
-- Definition in terms of :math:`T`-matrix
+- Definition in terms of $T$-matrix
 
-Special cases of the :math:`K`-matrix
--------------------------------------
+Special cases of the $K$-matrix
+-------------------------------
 
 Breit-Wigner
 """"""""""""

--- a/src/theory/formalisms.rst
+++ b/src/theory/formalisms.rst
@@ -33,12 +33,11 @@ Helicity Formalism
   :class: dropdown
 
   Two particle states are the key element here. With these one can construct
-  states of total spin :math:`J` and projection :math:`M`.
+  states of total spin $J$ and projection $M$.
 
   The probability amplitude of a state with spin J and projection M decaying
-  into two particles 1 and 2 with helicities :math:`\lambda_i` and momentum
-  :math:`\vec{p}` in the cms frame is given by
-  :cite:`chungSpinFormalismsUpdated2014`, p.16.
+  into two particles 1 and 2 with helicities $\lambda_i$ and momentum $\vec{p}$
+  in the cms frame is given by :cite:`chungSpinFormalismsUpdated2014`, p.16.
 
   .. math::
 
@@ -73,8 +72,8 @@ Canonical Formalism
 .. admonition:: The old text
   :class: dropdown
 
-  The canonical formalism gives access to the orbital angular momentum
-  :math:`L` and the coupled Spin :math:`S` arising from a two particle state.
+  The canonical formalism gives access to the orbital angular momentum $L$ and
+  the coupled Spin $S$ arising from a two particle state.
 
   There is a simple connection between the two formalism. Show that here
 

--- a/src/theory/glossary.rst
+++ b/src/theory/glossary.rst
@@ -16,15 +16,15 @@ section on these pages.
     The fact that the :term:`coupling constant` of the strong force increases
     in strength for lower momentum.
 
+  baryon
+    A particle that consists of three quarks.
+
   color confinement
     The fact that quarks only exist in colorless, bound states (quark groups of
     which the colors add up to 'white'). See also :term:`asymptotic freedom`.
 
   coupling constant
     <define>
-
-  baryon
-    A particle that consists of three quarks.
 
   hadron
     Particles that consist of two quarks (:term:`meson`) or three quarks
@@ -54,8 +54,8 @@ section on these pages.
     See `PDG review on Resonances
     <https://pdg.lbl.gov/2020/reviews/rpp2020-rev-resonances.pdf>`_
 
-  strong force
-    One of the four fundamental forces of the :term:`Standard Model`
-
   Standard Model
     Most fundamental description of matter and forces
+
+  strong force
+    One of the four fundamental forces of the :term:`Standard Model`

--- a/src/theory/introduction.rst
+++ b/src/theory/introduction.rst
@@ -38,7 +38,7 @@ Transition amplitude
 """"""""""""""""""""
 
 - Amplitudes and intensities
-- (?) Lead-up to :math:`T`-matrix
+- (?) Lead-up to $T$-matrix
 - Distinction dynamical part and angular part
 
 .. admonition:: The old text
@@ -51,7 +51,7 @@ Transition amplitude
   from the experiment and the theoretical model is needed.
 
   The probability amplitude :cite:`weinbergQuantumTheoryFields1995`, p.113 of
-  an initial state :math:`\Psi_i` going to a final state :math:`\Psi_f` is:
+  an initial state $\Psi_i$ going to a final state $\Psi_f$ is:
 
   .. math::
 
@@ -65,7 +65,7 @@ Transition amplitude
   states, since many experimental measurements fall under these two
   categories:
 
-  1. Single particles in the initial state (:math:`N_I=1`)
+  1. Single particles in the initial state ($N_I=1$)
 
      This is a single particle decaying into the final state particles. Here
      the decay rate :cite:`weinbergQuantumTheoryFields1995`, p.136 is
@@ -74,10 +74,10 @@ Transition amplitude
 
          d\Gamma(i \rightarrow f) = 2\pi |M_{fi}|^2 \delta^4(p_f - p_i) d\Phi_f
 
-     :math:`d\Phi_f` is the phase space element of the final state, which is
+     $d\Phi_f$ is the phase space element of the final state, which is
      needed to make a comparison with data. More on this below.
 
-  2. Two particles in the initial state (:math:`N_I=2`)
+  2. Two particles in the initial state ($N_I=2$)
 
      The cross section of a two particle scattering/production process
      :cite:`weinbergQuantumTheoryFields1995`, p.137 is
@@ -86,7 +86,7 @@ Transition amplitude
 
          d\sigma(i \rightarrow f) = (2\pi)^4 u_i^{-1} |M_{fi}|^2 \delta^4(p_f - p_i) d\Phi_f
 
-     with :math:`u_i^{-1}` the relative velocity of the initial state
+     with $u_i^{-1}$ the relative velocity of the initial state
      particles.
 
   Describing multi body problems (more than 2) is a difficult task, since the

--- a/src/theory/topics.rst
+++ b/src/theory/topics.rst
@@ -8,13 +8,13 @@ Other topics (**re-categorize!**)
 
 - Phase-space
 - Coherent vs incoherent
-- :math:`P`-vector
-- (?) :math:`S`-matrix
+- $P$-vector
+- (?) $S$-matrix
 - (?) Spin density
 - Constituent Quark Model
 
   - Asymptotic freedom and color confinement
-  - :math:`J^CP(I^G)`
+  - $J^CP(I^G)$
   - Multiplets categorization
   - Importance of experimental data
 

--- a/src/theory/topics/cqm.rst
+++ b/src/theory/topics/cqm.rst
@@ -14,16 +14,16 @@ Asymptotic Freedom
 Mesons and Baryons
 ------------------
 
-* Quantum numbers (:math:`J^{CP}(I^G)`)
-    - baryon number :math:`B`
-    - hypercharge :math:`Y`
-    - charge :math:`Q`
-    - orbital angular momentum :math:`L`
-    - total spin :math:`J`
-    - parity :math:`P`
-    - charge :math:`Q`
-    - isospin :math:`I`
-    - general parity :math:`G`
+* Quantum numbers ($J^{CP}(I^G)$)
+    - baryon number $B$
+    - hypercharge $Y$
+    - charge $Q$
+    - orbital angular momentum $L$
+    - total spin $J$
+    - parity $P$
+    - charge $Q$
+    - isospin $I$
+    - general parity $G$
 * multiplets
     - pseudoscalar mesons
     - vector mesons


### PR DESCRIPTION
Allows one to write for instance `$\psi` instead of `:math:\psi:` in reST files.