### PR TITLE
ci: add Sphinx wiki role

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,4 +61,5 @@ ignore_directives =
     toggle,
 ignore_roles =
     cite,
+    wiki,
 report=warning

--- a/src/conf.py
+++ b/src/conf.py
@@ -5,6 +5,11 @@ list see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
+from docutils import nodes
+from typing import Dict
+
+from sphinx.application import Sphinx
+
 # -- Project information -----------------------------------------------------
 project = "PWA Software Pages"
 copyright = "2020"
@@ -94,6 +99,27 @@ linkcheck_ignore = []
 
 # Settings for myst-parser
 myst_update_mathjax = False
+
+# Add roles to simplify external linnks
+def setup(app: Sphinx):
+    app.add_role(
+        "wiki", autolink("https://en.wikipedia.org/wiki/%s", {"_": " "})
+    )
+
+
+def autolink(pattern: str, replace_mapping: Dict[str, str]):
+    def role(
+        name, rawtext, text: str, lineno, inliner, options={}, content=[]
+    ):
+        output_text = text
+        for search, replace in replace_mapping.items():
+            output_text = output_text.replace(search, replace)
+        url = pattern % (text,)
+        node = nodes.reference(rawtext, output_text, refuri=url, **options)
+        return [node], []
+
+    return role
+
 
 # Specify bibliography style
 from pybtex.plugin import register_plugin

--- a/src/software/git/branching.rst
+++ b/src/software/git/branching.rst
@@ -169,9 +169,9 @@ untouched ``master`` branch!
 Here, let's just remove all lines but for "some content" (the ``master``) and
 safe the file. Then it's a matter of staging the modified :file:`file1.txt` and
 creating a new **merge commit**. This time, we commit the :command:`-m` message
-flag for the :command:`git commit` command. Git will launch `vi
-<https://en.wikipedia.org/wiki/Vi>`_ with a pre-generated merge message. Just
-safe it (:command:`:x`) and Git will use it as a commit message.
+flag for the :command:`git commit` command. Git will launch :wiki:`Vi` with a
+pre-generated merge message. Just safe it (:command:`:x`) and Git will use it
+as a commit message.
 
 .. code-block:: shell
 

--- a/src/software/git/commit.rst
+++ b/src/software/git/commit.rst
@@ -54,10 +54,9 @@ snapshots (called "`commits
 that store **all files**, but does so smartly: files that haven't changed with
 regard to the previous commit are only stored as a link to that previous
 commit. A commit has to be given a short description (a message), but is always
-uniquely identifiable, because it is marked with a `SHA-1 checksum
-<https://en.wikipedia.org/wiki/SHA-1>`_ over all files that it contains (plus a
-timestamp). To :command:`git commit` the staged file with a certain message
-(:command:`-m`), run:
+uniquely identifiable, because it is marked with a :wiki:`SHA-1` checksum over
+all files that it contains (plus a timestamp). To :command:`git commit` the
+staged file with a certain message (:command:`-m`), run:
 
 .. code-block:: shell
 


### PR DESCRIPTION
Allows one to write e.g. `:wiki:Fourier_transform` instead of
```rst
`Fourier Transform <https://en.wikipedia.org/wiki/Fourier_transform>`_
```