### PR TITLE
build: split requirements for dev extras

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,36 +8,6 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
-  test:
-    name: Run pytest
-    if: startsWith(github.ref, 'refs/tags')
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - macos-10.15
-          - ubuntu-18.04
-        python-version: [3.6, 3.7, 3.8]
-        exclude:
-          - os: macos-10.15
-            python-version: 3.6
-          - os: macos-10.15
-            python-version: 3.8
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .[test]
-      - name: Test with pytest
-        env:
-          PYTEST_RUN_SLOW_TESTS: YES
-        run: pytest -n auto
-
   documentation:
     name: Build documentation and run notebooks
     if: startsWith(github.ref, 'refs/tags')
@@ -93,7 +63,6 @@ jobs:
     needs:
       - documentation
       - style
-      - test
     steps:
       - uses: actions/checkout@master
       - name: Push to stable branch

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          pip install .[ci]
           sudo npm install -g cspell markdownlint-cli pyright
       - name: Perform style checks
         run: tox -e sty

--- a/.github/workflows/ci-epic.yml
+++ b/.github/workflows/ci-epic.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          pip install .[ci]
       - name: Perform style checks
         run: tox -e sty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          pip install .[ci]
           sudo npm install -g cspell markdownlint-cli pyright
       - name: Perform style checks
         run: tox -e sty

--- a/docs/software/git/branching.rst
+++ b/docs/software/git/branching.rst
@@ -22,7 +22,7 @@ initializing a repository, Git automatically creates a branch called
 
 .. code-block:: shell
 
-    git branch
+  git branch
 
 There is a ``master`` branch next to the ``HEAD`` (which is in a "detached"
 state). The master moved along on to the second commit you made and stayed
@@ -32,8 +32,8 @@ branch ``new_idea``:
 
 .. code-block:: shell
 
-    git branch new_idea
-    git branch -v
+  git branch new_idea
+  git branch -v
 
 The second commands prints the existing branches along with the commits they
 point to. You'll see that there is a ``new_idea`` branch pointing to the first
@@ -81,19 +81,19 @@ them, and creating a new commit from those changes:
 
 .. code-block:: shell
 
-    echo "this content is much better!" > file1.txt
-    echo "from the new idea" > file2.txt
-    git add -A
-    git commit -m "fix: add content to files"
+  echo "this content is much better!" > file1.txt
+  echo "from the new idea" > file2.txt
+  git add -A
+  git commit -m "fix: add content to files"
 
 There is a nice way to visualize the current situation (so nice, in fact, that
 we label it):
 
 .. code-block:: shell
-    :caption: Visualize branching tree
-    :name: visualize-branches
+  :caption: Visualize branching tree
+  :name: visualize-branches
 
-    git log --graph --all --oneline
+  git log --graph --all --oneline
 
 This shows that there are now three commits: the initial commit, the commit to
 which the ``master`` branch points, and the commit to which the ``new_idea``
@@ -104,12 +104,12 @@ branch and the HEAD currently point. The dashes also nicely display that the
 
 .. code-block:: shell
 
-    mkdir folder
-    mv file2.txt folder/moved_file.txt
-    git add folder
-    git rm file2.txt
-    git status -s
-    git commit -m "refactor: move file"
+  mkdir folder
+  mv file2.txt folder/moved_file.txt
+  git add folder
+  git rm file2.txt
+  git status -s
+  git commit -m "refactor: move file"
 
 Notice that we used :command:`git status -s`, a nice way to summarize the
 situation in the working tree. In this case, it shows that :file:`file2.txt`
@@ -126,8 +126,8 @@ the old ones from the ``master`` branch (but see the sidebar note).
 
 .. code-block:: shell
 
-    git checkout master
-    ls
+  git checkout master
+  ls
 
 Let's see what happens if we `merge
 <https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging>`_
@@ -135,7 +135,7 @@ the ``new_idea`` branch *into* the ``master``:
 
 .. code-block::
 
-    git merge new_idea
+  git merge new_idea
 
 Wow, what's this?? Git tells it is "removing :file:`file2.txt`", but then runs
 into a conflict for :file:`file1.txt`. Here we see that *Git does line-wise
@@ -146,17 +146,17 @@ file itself and is waiting for your input. If you have a look in the file:
 
 .. code-block:: shell
 
-    vi file1.txt
+  vi file1.txt
 
 you'll see:
 
 .. code-block::
 
-    <<<<<<< HEAD
-    this content is much better!
-    =======
-    some content
-    >>>>>>> master
+  <<<<<<< HEAD
+  this content is much better!
+  =======
+  some content
+  >>>>>>> master
 
 It shows that "some content" was the line from the ``master`` branch and "this
 content is much better!" came in from the ``HEAD`` (the ``HEAD`` was moved to
@@ -175,8 +175,8 @@ as a commit message.
 
 .. code-block:: shell
 
-    git add file1.txt
-    git commit
+  git add file1.txt
+  git commit
 
 If we again :ref:`visualize the branch structure <visualize-branches>`, we see
 something cool: the "initial commit" branches off into two branches, then
@@ -186,7 +186,7 @@ delete it now that the 'new idea' has been merged with the ``master``:
 
 .. code-block:: shell
 
-    git branch -d new_idea
+  git branch -d new_idea
 
 That's it, the fundamentals of branching! To be sure, the example here is
 trivial, but what makes Git so powerful is that it can handle large numbers of

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: pwa-pages
 channels:
   - defaults
 dependencies:
-  - python>=3.6
+  - python>=3.6,<3.9
   - pip
   - graphviz # for binder
   - pip:

--- a/setup.cfg
+++ b/setup.cfg
@@ -130,6 +130,7 @@ ignore_directives =
     tabbed,
     thebe-button,
     toggle,
+ignore_messages = (Error in "code-block" directive:$)
 ignore_roles =
     cite,
     wiki,

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,8 +66,10 @@ doc =
     sphinx-thebe==0.0.8
     sphinx-togglebutton==0.2.3
     sphinxcontrib-bibtex==1.0.0
-dev =
-    %(doc)s
+format =
+    black==20.8b1
+    isort==5.6.1
+lint =
     black==20.8b1
     data-science-types==0.2.19
     doc8==0.8.1
@@ -76,19 +78,26 @@ dev =
     flake8-bugbear==20.1.4
     flake8-builtins==1.5.3
     flake8-rst-docstrings==0.0.13
-    isort==5.6.1
+    mypy==0.782
+    nbstripout==0.3.8
+    pep8-naming==0.11.1
+    pydocstyle==5.1.1
+    pylint==2.6.0
+    rstcheck==3.3.1
+ci =
+    %(format)s
+    %(lint)s
+    pre-commit==2.8.2
+    tox==3.20.0
+tools =
     jupyterlab==2.2.4
     jupyterlab_code_formatter==1.3.6
     jupyter_nbextensions_configurator==0.4.1
     labels==20.1.0
-    mypy==0.782
-    nbstripout==0.3.8
-    pep8-naming==0.11.1
-    pre-commit==2.8.2
-    pydocstyle==5.1.1
-    pylint==2.6.0
-    rstcheck==3.3.1
-    tox==3.20.0
+dev =
+    %(ci)s
+    %(doc)s
+    %(tools)s
 
 [doc8]
 extension=.inc


### PR DESCRIPTION
Some of the dependencies listed under `dev` are not required for the style checks that are run with `tox -e sty`. This slows down the GitHub CI workflow.