### PR TITLE
ci: use installed packages for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,23 +25,6 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-      - id: black
-
-  - repo: https://github.com/PyCQA/doc8
-    rev: 0.8.1
-    hooks:
-      - id: doc8
-        args: ["-q"]
-
-  - repo: https://github.com/kynan/nbstripout
-    rev: 0.3.8
-    hooks:
-      - id: nbstripout
-        files: ".ipynb"
-
   - repo: https://github.com/prettier/prettier
     rev: 2.1.2
     hooks:
@@ -50,6 +33,21 @@ repos:
 
   - repo: local
     hooks:
+      - id: black
+        name: black
+        entry: black
+        language: system
+        types:
+          - python
+
+      - id: doc8
+        name: doc8
+        entry: doc8
+        args:
+          - -q
+        language: system
+        files: \.(inc|rst)$
+
       - id: flake8
         name: flake8
         entry: flake8
@@ -71,6 +69,13 @@ repos:
         types:
           - python
 
+      - id: nbstripout
+        name: nbstripout
+        entry: nbstripout
+        language: system
+        types:
+          - jupyter
+
       - id: pydocstyle
         name: pydocstyle
         entry: pydocstyle
@@ -80,7 +85,10 @@ repos:
 
       - id: pylint
         name: pylint
-        entry: pylint --rcfile=.pylintrc --score=no
+        entry: pylint
+        args:
+          - --rcfile=.pylintrc
+          - --score=no
         language: system
         types:
           - python

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ dev =
     mypy==0.782
     nbstripout==0.3.8
     pep8-naming==0.11.1
-    pre-commit==2.7.1
+    pre-commit==2.8.2
     pydocstyle==5.1.1
     pylint==2.6.0
     rstcheck==3.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,7 @@ dev =
     jupyter_nbextensions_configurator==0.4.1
     labels==20.1.0
     mypy==0.782
+    nbstripout==0.3.8
     pep8-naming==0.11.1
     pre-commit==2.7.1
     pydocstyle==5.1.1


### PR DESCRIPTION
Pre-commit slows down CI because many of its hooks completely clone repositories such as that of `doc8`. This PR lets pre-commit use the Python packages that are installed through the `dev` extras.

Added benefit: the `setup.cfg` file becomes the source of truth for dependency versions.

Note that the biggest package -- Prettier -- is still cloned, because this is a Node.js package that can't be installed through `pip`.