### PR TITLE
ci: implement markdownlint pre-commit hook

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,8 @@ root = true
 [*]
 end_of_line = lf
 indent_style = space
-trim_trailing_whitespace = true
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [Makefile]
 indent_style = tab

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,13 +47,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[precommit]
-          sudo npm install -g cspell markdownlint-cli pyright
+          sudo npm install -g cspell pyright
       - name: Perform style checks
         run: pre-commit run -a
       - name: Check spelling
         run: cspell $(git ls-files)
-      - name: Lint Markdown files
-        run: markdownlint .
       - name: Run pyright
         run: pyright
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[precommit]
-          sudo npm install -g cspell markdownlint-cli pyright
+          sudo npm install -g cspell pyright
       - name: Perform style checks
         run: pre-commit run -a
       - name: Check spelling
         run: cspell $(git ls-files)
-      - name: Lint Markdown files
-        run: markdownlint .
       - name: Run pyright
         run: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,11 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.25.0
+    hooks:
+      - id: markdownlint
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.2.0
     hooks:

--- a/cspell.json
+++ b/cspell.json
@@ -18,8 +18,10 @@
     ],
     "ignorePaths": [
         "*.bib",
+        "*.root",
         "*.rst_t",
         "*.svg",
+        "*particle*.*ml",
         ".gitignore",
         ".gitpod.*",
         ".pre-commit-config.yaml",

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -160,7 +160,7 @@ If you have Node.js (`npm`) on your system, you can run a few additional
 checks. Install these packages as follows (possibly with administrator rights):
 
 ```bash
-npm install -g cspell markdownlint-cli pyright
+npm install -g cspell pyright
 ```
 
 Note that [`pyright`](https://github.com/microsoft/pyright) requires Node.js

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ lint =
 precommit =
     %(format)s
     %(lint)s
-    pre-commit==2.8.2
+    pre-commit==2.9.0
 tox =
     %(precommit)s
     sphinx-autobuild==2020.9.1

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,6 @@ commands =
         --open-browser \
         docs/ docs/_build/html
 
-
 [testenv:linkcheck]
 description =
     Check external links in the documentation (requires internet connection)
@@ -54,7 +53,6 @@ commands =
     mypy .  # run separately because of potential caching problems
     pre-commit run {posargs} -a
     - bash -ec "cspell $(git ls-files)"
-    - bash -ec "markdownlint . --ignore docs/_build"
 
 [flake8]
 application-import-names =


### PR DESCRIPTION
- Removes the need to `npm`-install `markdownlint`.
- Upgrades `pre-commit`.
- Also did some alphabetical sorts in config files.