### PR TITLE
ci!: run cspell as pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r reqs/3.7/requirements-sty.txt
           pip install .
-          sudo npm install -g cspell pyright
+          sudo npm install -g pyright
       - name: Perform style checks
         run: pre-commit run -a
-      - name: Check spelling
-        run: cspell --no-progress $(git ls-files)
       - name: Run pyright
         run: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,11 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
+  - repo: https://github.com/ComPWA/mirrors-cspell
+    rev: v5.3.9
+    hooks:
+      - id: cspell
+
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.25.0
     hooks:

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -166,7 +166,7 @@ If you have Node.js (`npm`) on your system, you can run a few additional
 checks. Install these packages as follows (possibly with administrator rights):
 
 ```shell
-npm install -g cspell pyright
+npm install -g pyright
 ```
 
 :::
@@ -355,7 +355,8 @@ Throughout this repository, we follow American English
 conventions. As a tool, we use
 [cSpell](https://github.com/streetsidesoftware/cspell/blob/master/packages/cspell/README.md),
 because it allows to check variable names in camel case and snake case. This
-way, a spelling checker helps you avoid mistakes in the code as well!
+way, a spelling checker helps you avoid mistakes in the code as well! cSpell is
+enforced through pre-commit.
 
 Accepted words are tracked through the {download}`cspell.json <../cspell.json>`
 file. As with the other config files, {download}`cspell.json <../cspell.json>`
@@ -371,10 +372,7 @@ It is easiest to use cSpell in {ref}`develop:Visual Studio Code`, through the
 [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)
 extension: it provides linting, suggests corrections from the {code}`words`
 section, and enables you to quickly add or ignore words through the
-{file}`cspell.json` file. Alternatively, you can
-[run cSpell](https://www.npmjs.com/package/cspell#installation) on the entire
-code base (with {code}`cspell $(git ls-files)`), but for that your system
-requires [npm](https://www.npmjs.com).
+{file}`cspell.json` file.
 
 ## Testing
 

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,6 @@ allowlist_externals =
 commands =
     mypy src tests  # run separately because of potential caching problems
     pre-commit run {posargs} -a
-    - bash -ec "cspell --no-progress $(git ls-files)"
 
 [flake8]
 application-import-names =


### PR DESCRIPTION
[cSpell](https://github.com/streetsidesoftware/cspell) is now enforced through [`pre-commit`](https://github.com/ComPWA/mirrors-cspell). This means that there is no need anymore to install cSpell through `npm` and that spelling is checked upon committing :tada: 

For more info, see [github.com/ComPWA/mirrors-cspell](https://github.com/ComPWA/mirrors-cspell).