### PR TITLE
ci: add pyright and ComPWA/meta pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r reqs/3.7/requirements-sty.txt
           pip install .
-          sudo npm install -g pyright
       - name: Perform style checks
         run: pre-commit run -a
-      - name: Run pyright
-        run: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,11 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
+  - repo: https://github.com/ComPWA/meta
+    rev: 0.0.1
+    hooks:
+      - id: fix-nbformat-version
+
   - repo: https://github.com/ComPWA/mirrors-cspell
     rev: v5.3.9
     hooks:
@@ -40,6 +45,11 @@ repos:
     hooks:
       - id: prettier
         language_version: 12.18.2 # prettier does not specify node correctly
+
+  - repo: https://github.com/ComPWA/mirrors-pyright
+    rev: v1.1.126
+    hooks:
+      - id: pyright
 
   # The following tools have to be install locally, because they can also be
   # used by code editors (e.g. linting and format-on-save).


### PR DESCRIPTION
- No need to install [Pyright](https://github.com/microsoft/pyright) anymore (through `npm`), because it is now executed as a `pre-commit` hook. See [ComPWA/mirrors-pyright](https://github.com/ComPWA/mirrors-pyright).
- Added hooks from the [ComPWA/meta](https://github.com/ComPWA/meta) repository.