### PR TITLE
ci: add pre-commit hook for editorconfig

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: fix-nbformat-version
 
   - repo: https://github.com/ComPWA/mirrors-cspell
-    rev: v5.3.11
+    rev: v5.3.12
     hooks:
       - id: cspell
 
@@ -50,7 +50,7 @@ repos:
         language_version: 12.18.2 # prettier does not specify node correctly
 
   - repo: https://github.com/ComPWA/mirrors-pyright
-    rev: v1.1.128
+    rev: v1.1.130
     hooks:
       - id: pyright
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,11 @@ repos:
     hooks:
       - id: cspell
 
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
+    rev: 2.3.5
+    hooks:
+      - id: editorconfig-checker
+
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.27.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,14 @@ include = '\.pyi?$'
 exclude = '''
 /(
     .*\.egg-info
-  | .*build
-  | \.eggs
-  | \.git
-  | \.pytest_cache
-  | \.tox
-  | \.venv
-  | \.vscode
-  | dist
+    | .*build
+    | \.eggs
+    | \.git
+    | \.pytest_cache
+    | \.tox
+    | \.venv
+    | \.vscode
+    | dist
 )/
 '''
 


### PR DESCRIPTION
See [here](https://github.com/editorconfig-checker/editorconfig-checker.python). Previously, [EditorConfig](https://editorconfig.org) formatting was only configured through the editor.