### PR TITLE
ci: standardize cspell config

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -16,13 +16,13 @@
         "parmater"
     ],
     "ignorePaths": [
+        "**/.cspell.json",
         "*.bib",
         "*.ico",
         "*.root",
         "*.rst_t",
         "*.svg",
         "*particle*.*ml",
-        ".cspell.json",
         ".gitignore",
         ".gitpod.*",
         ".pre-commit-config.yaml",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.4
+    rev: 0.0.5
     hooks:
       - id: check-dev-files
       - id: fix-first-nbcell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.3
+    rev: 0.0.4
     hooks:
       - id: check-dev-files
       - id: fix-first-nbcell

--- a/reqs/3.6/requirements-dev.txt
+++ b/reqs/3.6/requirements-dev.txt
@@ -57,7 +57,7 @@ jinja2==2.11.3
 json5==0.9.5
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-packaging==0.7.12

--- a/reqs/3.6/requirements-dev.txt
+++ b/reqs/3.6/requirements-dev.txt
@@ -161,7 +161,7 @@ toml==0.10.2
 tornado==6.1
 tox==3.23.0
 traitlets==4.3.3
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 urllib3==1.26.4
 virtualenv==20.4.3

--- a/reqs/3.6/requirements-doc.txt
+++ b/reqs/3.6/requirements-doc.txt
@@ -39,7 +39,7 @@ jedi==0.18.0
 jinja2==2.11.3
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-sphinx==0.3.1

--- a/reqs/3.6/requirements-sty.txt
+++ b/reqs/3.6/requirements-sty.txt
@@ -58,7 +58,7 @@ six==1.15.0
 snowballstemmer==2.1.0
 toml==0.10.2
 traitlets==4.3.3
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 virtualenv==20.4.3
 wrapt==1.12.1

--- a/reqs/3.7/requirements-dev.txt
+++ b/reqs/3.7/requirements-dev.txt
@@ -53,7 +53,7 @@ jinja2==2.11.3
 json5==0.9.5
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-packaging==0.7.12

--- a/reqs/3.7/requirements-dev.txt
+++ b/reqs/3.7/requirements-dev.txt
@@ -157,7 +157,7 @@ toml==0.10.2
 tornado==6.1
 tox==3.23.0
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 urllib3==1.26.4
 virtualenv==20.4.3

--- a/reqs/3.7/requirements-doc.txt
+++ b/reqs/3.7/requirements-doc.txt
@@ -37,7 +37,7 @@ jedi==0.18.0
 jinja2==2.11.3
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-sphinx==0.3.1

--- a/reqs/3.7/requirements-sty.txt
+++ b/reqs/3.7/requirements-sty.txt
@@ -55,7 +55,7 @@ six==1.15.0
 snowballstemmer==2.1.0
 toml==0.10.2
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 virtualenv==20.4.3
 wrapt==1.12.1

--- a/reqs/3.8/requirements-dev.txt
+++ b/reqs/3.8/requirements-dev.txt
@@ -53,7 +53,7 @@ jinja2==2.11.3
 json5==0.9.5
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-packaging==0.7.12

--- a/reqs/3.8/requirements-dev.txt
+++ b/reqs/3.8/requirements-dev.txt
@@ -157,7 +157,7 @@ toml==0.10.2
 tornado==6.1
 tox==3.23.0
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 urllib3==1.26.4
 virtualenv==20.4.3

--- a/reqs/3.8/requirements-doc.txt
+++ b/reqs/3.8/requirements-doc.txt
@@ -37,7 +37,7 @@ jedi==0.18.0
 jinja2==2.11.3
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-sphinx==0.3.1

--- a/reqs/3.8/requirements-sty.txt
+++ b/reqs/3.8/requirements-sty.txt
@@ -54,7 +54,7 @@ six==1.15.0
 snowballstemmer==2.1.0
 toml==0.10.2
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 virtualenv==20.4.3
 wrapt==1.12.1

--- a/reqs/3.9/requirements-dev.txt
+++ b/reqs/3.9/requirements-dev.txt
@@ -53,7 +53,7 @@ jinja2==2.11.3
 json5==0.9.5
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-packaging==0.7.12

--- a/reqs/3.9/requirements-dev.txt
+++ b/reqs/3.9/requirements-dev.txt
@@ -157,7 +157,7 @@ toml==0.10.2
 tornado==6.1
 tox==3.23.0
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 urllib3==1.26.4
 virtualenv==20.4.3

--- a/reqs/3.9/requirements-doc.txt
+++ b/reqs/3.9/requirements-doc.txt
@@ -37,7 +37,7 @@ jedi==0.18.0
 jinja2==2.11.3
 jsonschema==3.2.0
 jupyter-cache==0.4.2
-jupyter-client==6.1.12
+jupyter-client==6.2.0
 jupyter-console==6.4.0
 jupyter-core==4.7.1
 jupyter-sphinx==0.3.1

--- a/reqs/3.9/requirements-sty.txt
+++ b/reqs/3.9/requirements-sty.txt
@@ -54,7 +54,7 @@ six==1.15.0
 snowballstemmer==2.1.0
 toml==0.10.2
 traitlets==5.0.5
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 virtualenv==20.4.3
 wrapt==1.12.1


### PR DESCRIPTION
Use the new `check-dev-files` hook to rename and format the `.cspell.json` file.