### PR TITLE
build: remove mdit-py-plugins version limit

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,6 +39,12 @@
   "git.rebaseWhenSync": true,
   "githubPullRequests.telemetry.enabled": false,
   "gitlens.advanced.telemetry.enabled": false,
+  "myst.preview.extensions": [
+    "amsmath",
+    "colon_fence",
+    "dollarmath",
+    "tasklist"
+  ],
   "python.analysis.autoImportCompletions": false,
   "python.analysis.diagnosticMode": "workspace",
   "python.formatting.provider": "black",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # How to contribute?
 
 [![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/ComPWA/PWA-pages)
+[![GitPod](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/ComPWA/PWA-pages)
 
 See instructions at
 [pwa.readthedocs.io/develop](https://pwa.readthedocs.io/develop.html)!

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Documentation build status](https://readthedocs.org/projects/pwa/badge/?version=latest)](https://pwa.readthedocs.io)
 [![GPLv3+ license](https://img.shields.io/badge/License-GPLv3+-blue.svg)](https://www.gnu.org/licenses/gpl-3.0-standalone.html)
+[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/ComPWA/PWA-pages)
 [![GitPod](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/ComPWA/PWA-pages)
 [![CI status](https://github.com/ComPWA/PWA-pages/workflows/CI/badge.svg)](https://github.com/ComPWA/PWA-pages/actions?query=branch%3Amain+workflow%3ACI)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen)](https://github.com/pre-commit/pre-commit)

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -248,10 +248,12 @@ activated, but only once, after you clone the repository:
 pre-commit install
 ```
 
-```{margin} Initializing pre-commit
+:::{margin} Initializing pre-commit
+
 The first time you run {command}`pre-commit` after installing or updating its
 checks, it may take some time to initialize.
-```
+
+:::
 
 Upon committing, {command}`pre-commit` now runs a set of checks as defined in
 the file
@@ -272,10 +274,12 @@ these tools.
 
 More thorough checks can be run in one go with the following command:
 
-```{margin} Running jobs in parallel
+:::{margin} Running jobs in parallel
+
 The {code}`-p` flag lets the jobs run in parallel. It also provides a nicer
 overview of the progress. See {ref}`tox:parallel_mode`.
-```
+
+:::
 
 ```shell
 tox -p
@@ -357,15 +361,17 @@ are formulated in config files. For linters, we use the following:
   - [pydocstyle](https://pydocstyle.pycqa.org)
   - [pytest](https://docs.pytest.org)
 
-:::{toggle}
+::::{toggle}
 
-```{note}
+:::{note}
+
 As an illustration of automated checks, we list the files here with links to
-the actual files as to ensure that these files still exist and that
-this documentation remains up to date.
-```
+the actual files as to ensure that these files still exist and that this
+documentation remains up to date.
 
 :::
+
+::::
 
 ### Spelling
 
@@ -405,17 +411,18 @@ pytest -n auto
 The flag {command}`-n auto` causes {code}`pytest` to
 [run with a distributed strategy](https://pypi.org/project/pytest-xdist).
 
-:::{margin}
+::::{margin}
 
-```{tip}
-In VScode, you can
-visualize test coverage are covered with
+:::{tip}
+
+In VScode, you can visualize test coverage are covered with
 [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters).
 For this you need to run {command}`pytest` with the flag
 {command}`--cov-report=xml`).
-```
 
 :::
+
+::::
 
 Try to keep test coverage high. You can compute current coverage by running
 
@@ -433,7 +440,8 @@ pytest --profile-svg
 
 and check the stats and the {file}`prof/combined.svg` output file.
 
-```{dropdown} Organizing unit tests
+:::{dropdown} Organizing unit tests
+
 When **unit** tests are well-organized, you avoid writing duplicate tests. In
 addition, it allows you to check for coverage of specific parts of the code.
 
@@ -447,12 +455,15 @@ folder. Similarly, bundle for a class {code}`SomeClass` under a
 
 If possible, also try to order the tests by alphabetical order (that is, the
 order of the {code}`import` statements).
-```
 
-```{note}
+:::
+
+:::{note}
+
 Jupyter notebooks can also be used as tests. See more info
 {ref}`here <develop:Jupyter Notebooks>`.
-```
+
+:::
 
 ## Documentation
 
@@ -512,16 +523,18 @@ or [Markdown](https://www.markdownguide.org). In addition, it's easy to write
 
 ### Jupyter Notebooks
 
-:::{margin}
+::::{margin}
 
-```{tip}
+:::{tip}
+
 Sometimes it happens that your Jupyter installation does not recognize your
 {ref}`virtual environment <develop:Virtual environment>`. In that case, have a
 look at
 [these instructions](https://ipython.readthedocs.io/en/stable/install/kernel_install.html#kernels-for-different-environments)
-```
 
 :::
+
+::::
 
 The [docs](https://github.com/ComPWA/PWA-pages/tree/main/docs) folder contains
 a few Jupyter notebooks. These notebooks are run and tested whenever you make a
@@ -608,11 +621,13 @@ branch can be found on RTD under "latest", see e.g.
 
 #### Epic branches
 
-```{margin}
+:::{margin}
+
 The word ["epic"](https://www.atlassian.com/agile/project-management/epics) is
 used in
 [agile software development](https://en.wikipedia.org/wiki/Agile_software_development).
-```
+
+:::
 
 When working on a feature or larger refactoring that may take a longer time
 (think of implementing a new PWA formalism), we isolate its development under

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,4 +1,4 @@
-<!--- cspell:ignore aitchison badalyan tanabashi -->
+<!-- cspell:ignore aitchison badalyan tanabashi -->
 
 # Glossary
 

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -47,7 +47,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While the {term}`Standard Model` provides an incredibly accurate description of the most fundamental constituents of matter, it remains difficult to describe interactions at the level of bound states ({term}`hadrons <hadron>`). This is because the fundamental force that dominates at this range---―the {term}`strong force`---is characterized by an {term}`asymptotic freedom`: it has a strong coupling constant at low momentum transfer.\n",
+    "While the {term}`Standard Model` provides an incredibly accurate description of the most fundamental constituents of matter, it remains difficult to describe interactions at the level of bound states ({term}`hadrons <hadron>`). This is because the fundamental force that dominates at this range―the {term}`strong force`―is characterized by an {term}`asymptotic freedom`: it has a strong coupling constant at low momentum transfer.\n",
     "\n",
     "One the one hand, this asymptotic behavior of the strong force forces {term}`quarks <quark>` to bound together in colorless groups ({term}`color confinement`), giving particle physicists an amazingly varied spectrum of quark combinations to study. On the other, the asymptotic running of the coupling constant makes it almost impossible to predict from first principles how bound states of quarks interact at lower energies.\n",
     "\n",

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,4 +1,4 @@
-<!--- cspell:ignore labelprefix -->
+<!-- cspell:ignore labelprefix -->
 
 # Bibliography
 

--- a/docs/software/git/branching.md
+++ b/docs/software/git/branching.md
@@ -20,7 +20,6 @@ initializing a repository, Git automatically creates a branch called `main`. In
 
 ```shell
 git branch
-
 ```
 
 There is a `main` branch next to the `HEAD` (which is in a "detached" state).
@@ -32,7 +31,6 @@ commit (the one that contains two empty files). Let's call this new branch
 ```shell
 git branch new_idea
 git branch -v
-
 ```
 
 The second commands prints the existing branches along with the commits they
@@ -44,7 +42,6 @@ branch, run:
 
 ```shell
 git checkout new_idea
-
 ```
 
 :::{sidebar} Checkout ambiguity

--- a/docs/software/git/branching.md
+++ b/docs/software/git/branching.md
@@ -1,4 +1,4 @@
-<!--- cspell:ignore Git's -->
+<!-- cspell:ignore Git's -->
 
 # Trying out different ideas: branching
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,6 @@ doc =
     graphviz
     ipywidgets
     jupyter
-    mdit-py-plugins < 0.2.7  # temporary fix
     myst-nb >= 0.11  # myst_enable_extensions
     Sphinx >= 3
     sphinx-book-theme


### PR DESCRIPTION
- Using more MyST column fences (`:::` instead of ```), because Prettier can handle them.
- Optimized workspace settings for [new version of the MyST VSCode extension](https://github.com/executablebooks/myst-vs-code/releases/tag/v0.11.0).
- Some style changes to the Markdown source code (100e61a, 80cf6a8).