### PR TITLE
ci: install only doc requirements on RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,5 +8,10 @@ sphinx:
 formats:
   - htmlzip
 
-conda:
-  environment: environment.yml
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc


### PR DESCRIPTION
This speeds up RTD because style checks and other dev tools are not installed.