### PR TITLE
docs: extend fitter package tables

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -29,6 +29,7 @@ jobs:
         working-directory: docs
         env:
           EXECUTE_NB: YES
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make html
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -26,4 +26,5 @@ jobs:
           sudo apt-get -y install graphviz pandoc
       - name: Check external links
         working-directory: docs
-        run: make ignore-warnings=1 linkcheck
+        run:
+          READTHEDOCS_VERSION=$GITHUB_HEAD_REF make ignore-warnings=1 linkcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.71
+    rev: 0.0.72
     hooks:
       - id: check-dev-files
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.72
+    rev: 0.0.74
     hooks:
       - id: check-dev-files
         args:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,7 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 import dataclasses
 import os
+import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -44,6 +45,13 @@ PACKAGE = "pwa_pages"
 REPO_NAME = "PWA-pages"
 copyright = "2020, ComPWA"  # noqa: A001
 author = "Common Partial Wave Analysis"
+
+# https://docs.readthedocs.io/en/stable/builds.html
+BRANCH = os.environ.get("READTHEDOCS_VERSION", default="main")
+if BRANCH == "latest":
+    BRANCH = "main"
+if re.match(r"^\d+$", BRANCH):  # PR preview
+    BRANCH = "main"
 
 if os.path.exists(f"../src/{PACKAGE}/version.py"):
     __release = get_distribution(PACKAGE).version
@@ -165,7 +173,6 @@ linkcheck_ignore = [
 
 # Settings for myst_nb
 execution_timeout = -1
-jupyter_execute_notebooks = "force"
 nb_output_stderr = "remove"
 nb_render_priority = {
     "html": (
@@ -181,6 +188,11 @@ nb_render_priority = {
     )
 }
 
+jupyter_execute_notebooks = "off"
+if "EXECUTE_NB" in os.environ:
+    print("\033[93;1mWill run Jupyter notebooks!\033[0m")
+    jupyter_execute_notebooks = "force"
+
 # Settings for myst-parser
 myst_enable_extensions = [
     "amsmath",
@@ -190,6 +202,7 @@ myst_enable_extensions = [
     "substitution",
 ]
 myst_substitutions = {
+    "branch": BRANCH,
     "build_date": datetime.today().strftime("%d %B %Y"),
 }
 myst_update_mathjax = False

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ These pages and are **under development**.
 The PWA Software Pages serve two purposes:
 
 1. They aim to bring together the
-   {ref}`many Partial Wave Analysis frameworks <software:Inventory of PWA projects>`
+   {ref}`many Partial Wave Analysis frameworks <software:Software inventory>`
    out there on the market through interlinked documentation.
 
 2. They provide a dynamic platform to collect and maintain knowledge on both

--- a/docs/software.ipynb
+++ b/docs/software.ipynb
@@ -47,14 +47,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Inventory of PWA projects"
+    "## Software inventory"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is a list of software frameworks or projects for amplitude analysis. Suggestions or fixes can easily be added through [this YAML file](https://github.com/ComPWA/PWA-pages/blob/main/docs/software/framework-inventory.yml) (click [here](https://github.com/ComPWA/PWA-pages/edit/main/docs/software/framework-inventory.yml) to edit)."
+    ":::{rubric} Amplitude analysis projects\n",
+    "\n",
+    ":::\n",
+    "\n",
+    "The following frameworks or projects are specifically designed to do amplitude analysis. The table is built from [this YAML file](https://github.com/ComPWA/PWA-pages/blob/main/docs/software/amplitude-analysis-projects.yml) and can be updated [here](https://github.com/ComPWA/PWA-pages/edit/main/docs/software/amplitude-analysis-projects.yml)."
    ]
   },
   {
@@ -79,7 +83,7 @@
     "    to_html_table,\n",
     ")\n",
     "\n",
-    "inventory_dict = load_yaml(\"software/framework-inventory.yml\")\n",
+    "inventory_dict = load_yaml(\"software/amplitude-analysis-projects.yml\")\n",
     "html_src = to_html_table(\n",
     "    inventory=ProjectInventory(**inventory_dict),\n",
     "    selected_languages=[\n",
@@ -97,8 +101,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    ":::{rubric} General fitter packages\n",
     "\n",
-    "_Last updated: {{ build_date }}_"
+    ":::\n",
+    "\n",
+    "The following packages do not have functionality for amplitude building, but can do fits with high performance. The YAML database for this table can be updated [here](https://github.com/ComPWA/PWA-pages/blob/main/docs/software/fitter-packages.yml)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "inventory_dict = load_yaml(\"software/fitter-packages.yml\")\n",
+    "html_src = to_html_table(\n",
+    "    inventory=ProjectInventory(**inventory_dict),\n",
+    "    selected_languages=[\n",
+    "        \"C++\",\n",
+    "        \"Python\",\n",
+    "        \"Cuda\",\n",
+    "    ],\n",
+    "    fetch=True,\n",
+    "    hide_columns=[\"Collaboration\"],\n",
+    ")\n",
+    "html_src = fix_html_alignment(html_src)\n",
+    "HTML(html_src)"
    ]
   },
   {
@@ -117,6 +152,13 @@
     "Have a look at [scikit-hep.org/developer](https://scikit-hep.org/developer) and [Towards a HEP Software Training curriculum](https://hepsoftwarefoundation.org/training/curriculum.html)! For development instructions for the ComPWA organization, see [Help developing](https://compwa-org.readthedocs.io/en/stable/develop.html).\n",
     "\n",
     ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "_Last update: {{ build_date }}_"
    ]
   }
  ],

--- a/docs/software.ipynb
+++ b/docs/software.ipynb
@@ -58,7 +58,10 @@
     "\n",
     ":::\n",
     "\n",
-    "The following frameworks or projects are specifically designed to do amplitude analysis. The table is built from [this YAML file](https://github.com/ComPWA/PWA-pages/blob/main/docs/software/amplitude-analysis-projects.yml) and can be updated [here](https://github.com/ComPWA/PWA-pages/edit/main/docs/software/amplitude-analysis-projects.yml)."
+    "The following frameworks or projects are specifically designed to do amplitude analysis. The table is built from\n",
+    "{{ '[this YAML file](https://github.com/ComPWA/PWA-pages/blob/{}/docs/software/amplitude-analysis-projects.yml)'.format(branch) }}\n",
+    "and can be updated\n",
+    "{{ '[here](https://github.com/ComPWA/PWA-pages/edit/{}/docs/software/amplitude-analysis-projects.yml)'.format(branch) }}."
    ]
   },
   {
@@ -105,7 +108,7 @@
     "\n",
     ":::\n",
     "\n",
-    "The following packages do not have functionality for amplitude building, but can do fits with high performance. The YAML database for this table can be updated [here](https://github.com/ComPWA/PWA-pages/blob/main/docs/software/fitter-packages.yml)."
+    "The following packages do not have functionality for amplitude building, but can do fits with high performance. The YAML database for this table can be updated {{ '[here](https://github.com/ComPWA/PWA-pages/edit/{}/docs/software/fitter-packages.yml)'.format(branch) }}."
    ]
   },
   {

--- a/docs/software/amplitude-analysis-projects.yml
+++ b/docs/software/amplitude-analysis-projects.yml
@@ -35,9 +35,6 @@ projects:
     languages:
       - C++
 
-  - name: Hydra
-    url: https://github.com/MultithreadCorner/Hydra
-
   - name: Ipanema
     url: https://gitlab.cern.ch/bsm-fleet/Ipanema
     languages:

--- a/docs/software/amplitude-analysis-projects.yml
+++ b/docs/software/amplitude-analysis-projects.yml
@@ -2,7 +2,7 @@
 
 projects:
   - name: AmpGen
-    url: https://github.com/GooFit/AmpGen/blob/master/README.md
+    url: https://github.com/GooFit/AmpGen
     collaboration:
       - CLEO
       - LHCb

--- a/docs/software/fitter-packages.yml
+++ b/docs/software/fitter-packages.yml
@@ -1,0 +1,17 @@
+# cspell:ignore Ampli GPUPWA ROOTPWA
+
+projects:
+  - name: GooFit
+    url: https://github.com/GooFit/GooFit
+
+  - name: Hydra
+    url: https://github.com/MultithreadCorner/Hydra
+
+  - name: RooFit
+    url: https://root.cern/manual/roofit
+    since: 2000
+    languages:
+      - C++
+
+  - name: zfit
+    url: https://github.com/zfit/zfit

--- a/docs/software/framework-inventory.yml
+++ b/docs/software/framework-inventory.yml
@@ -10,6 +10,9 @@ projects:
   - name: AmpTools
     url: https://github.com/mashephe/AmpTools
 
+  - name: ComPWA++
+    url: https://github.com/ComPWA/ComPWA
+
   - name: ComPWA project
     url: https://compwa-org.readthedocs.io/en/stable/about.html
     sub_projects:
@@ -22,6 +25,9 @@ projects:
     languages:
       - Python
 
+  - name: cFit
+    url: https://github.com/cfit/cfit
+
   - name: GPUPWA
     url: https://sourceforge.net/projects/gpupwa
     since: 2011
@@ -29,12 +35,24 @@ projects:
     languages:
       - C++
 
+  - name: Hydra
+    url: https://github.com/MultithreadCorner/Hydra
+
+  - name: Ipanema
+    url: https://gitlab.cern.ch/bsm-fleet/Ipanema
+    languages:
+      - C++
+      - CUDA
+
   - name: Laura++
     url: https://doi.org/10.1016/j.cpc.2018.04.017
     since: 2013
     collaboration: LHCb
     languages:
       - C++
+
+  - name: Mint2
+    url: https://github.com/jdalseno/Mint2
 
   - name: Pawian
     url: https://panda-wiki.gsi.de/foswiki/bin/view/PWA/PawianPwaSoftware

--- a/docs/software/project-inventory-schema.json
+++ b/docs/software/project-inventory-schema.json
@@ -11,6 +11,7 @@
     },
     "collaborations": {
       "title": "Collaborations",
+      "default": {},
       "type": "object",
       "additionalProperties": {
         "type": "string"
@@ -18,8 +19,7 @@
     }
   },
   "required": [
-    "projects",
-    "collaborations"
+    "projects"
   ],
   "definitions": {
     "SubProject": {

--- a/src/pwa_pages/project_inventory.py
+++ b/src/pwa_pages/project_inventory.py
@@ -127,9 +127,20 @@ def _checkmark_language(
     languages = project.languages
     if not languages and fetch:
         languages = _fetch_languages(project, min_percentage)
-    if language.lower() in map(lambda s: s.lower(), languages):
+    normalized_language = __replace_language(language).lower()
+    if normalized_language in map(lambda s: s.lower(), languages):
         return "✓"
     return ""
+
+
+def __replace_language(language: str) -> str:
+    replacements = {
+        "C": "C++",
+    }
+    for old, new in replacements.items():
+        if old.lower() == language.lower():
+            return new
+    return language
 
 
 def _fetch_languages(project: Project, min_percentage: float) -> List[str]:

--- a/src/pwa_pages/project_inventory.py
+++ b/src/pwa_pages/project_inventory.py
@@ -25,6 +25,7 @@ def to_html_table(
     *,
     fetch: bool = False,
     min_percentage: float = 2.5,
+    hide_columns: Optional[Iterable[str]] = None,
 ) -> str:
     header_to_formatters: Dict[str, Callable[[Project], str]] = {
         "Project": _create_project_entry,
@@ -41,6 +42,9 @@ def to_html_table(
             fetch=fetch,
             min_percentage=min_percentage,
         )
+    if hide_columns is not None:
+        for hide in hide_columns:
+            del header_to_formatters[hide]
 
     writer = HtmlTableWriter(
         headers=list(header_to_formatters),
@@ -82,7 +86,7 @@ class Project(BaseModel):
 
 class ProjectInventory(BaseModel):
     projects: List[Project]
-    collaborations: Dict[str, str]
+    collaborations: Dict[str, str] = {}
 
     @root_validator()
     def _check_collaboration_exists(cls, values: dict) -> dict:  # noqa: N805

--- a/tests/test_project_inventory.py
+++ b/tests/test_project_inventory.py
@@ -20,7 +20,7 @@ from pwa_pages.project_inventory import (
     to_html_table,
 )
 
-__MAX_PROJECTS = 3
+__MAX_PROJECTS = 4
 
 
 class TestProjectInventory:

--- a/tests/test_project_inventory.py
+++ b/tests/test_project_inventory.py
@@ -55,9 +55,16 @@ def docs_dir(this_dir) -> Path:
 
 @pytest.fixture(scope="session")
 def project_inventory(docs_dir: Path) -> ProjectInventory:
-    inventory_path = docs_dir / "software/framework-inventory.yml"
+    inventory_path = docs_dir / "software/amplitude-analysis-projects.yml"
     inventory_dict = load_yaml(inventory_path)
     inventory_dict["projects"] = inventory_dict["projects"][:__MAX_PROJECTS]
+    return ProjectInventory(**inventory_dict)
+
+
+@pytest.fixture(scope="session")
+def fitter_packages(docs_dir: Path) -> ProjectInventory:
+    inventory_path = docs_dir / "software/fitter-packages.yml"
+    inventory_dict = load_yaml(inventory_path)
     return ProjectInventory(**inventory_dict)
 
 
@@ -67,6 +74,13 @@ def test_load_project_inventory(project_inventory: ProjectInventory):
     assert inventory.projects[0].name == "AmpGen"
     assert "BESIII" in inventory.collaborations
     assert inventory.collaborations["BESIII"] == "http://bes3.ihep.ac.cn"
+
+
+def test_load_fitter_packages(fitter_packages: ProjectInventory):
+    assert len(fitter_packages.projects) > 1
+    # cspell:words zfit
+    assert "zfit" in {p.name for p in fitter_packages.projects}
+    assert "GooFit" in {p.name for p in fitter_packages.projects}
 
 
 def test_create_project_entry():
@@ -92,8 +106,8 @@ def test_checkmark_language():
     assert _checkmark_language(project, "Python", min_percentage=0) == ""
 
 
+@pytest.mark.parametrize("fetch", [False, True])
 @pytest.mark.parametrize("fix_alignment", [False, True])
-@pytest.mark.parametrize("fetch", [True, False])
 def test_to_html_table(project_inventory, fetch, fix_alignment):
     src = to_html_table(
         project_inventory,
@@ -106,6 +120,17 @@ def test_to_html_table(project_inventory, fetch, fix_alignment):
     assert src.startswith("<table>")
     assert src.count("<thead>") == 1
     assert src.count("<tr>") == __MAX_PROJECTS + 1
+
+
+def test_to_html_table_hide_columns(fitter_packages):
+    src = to_html_table(
+        fitter_packages,
+        selected_languages=["C++", "Python"],
+        fetch=False,
+        hide_columns=["Collaboration"],
+    )
+    assert src.startswith("<table>")
+    assert "Collaboration" not in src
 
 
 def test_export_export_json_schema(this_dir, docs_dir):

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,6 @@ changedir = docs
 allowlist_externals =
     make
 passenv =
-    GITHUB_TOKEN
     READTHEDOCS_VERSION
 commands =
     make html


### PR DESCRIPTION
* Listed more software projects in the inventory table ([latest](https://pwa.readthedocs.io/software.html) / [this build](https://pwa--142.org.readthedocs.build/software.html)). Credits to @tevans1260, see links to his presentations under dd90106.
* Split the software project table into two: general fitter package and projects that are specifically designed for amplitude analysis
