### PR TITLE
DOC: remove `.html` from page URLs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sphinx:
-  builder: html
+  builder: dirhtml
   configuration: docs/conf.py
   fail_on_warning: true
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
   sphinx-build \
     --keep-going \
     -TW \
-    -b html \
+    -b dirhtml \
     docs/ docs/_build/html
 description =
   Build documentation and API through Sphinx
@@ -66,6 +66,7 @@ commands =
     --re-ignore docs/_build/.* \
     --re-ignore docs/api \
     --watch docs \
+    -b dirhtml \
     docs/ docs/_build/html
 description =
   Set up a server to directly preview changes to the HTML pages
@@ -80,7 +81,7 @@ commands =
   sphinx-build \
     --keep-going \
     -TW \
-    -b html \
+    -b dirhtml \
     docs/ docs/_build/html
 description =
   Build documentation through Sphinx WITH output of Jupyter notebooks
@@ -111,6 +112,7 @@ commands =
     --re-ignore docs/_build/.* \
     --re-ignore docs/api \
     --watch docs \
+    -b dirhtml \
     docs/ docs/_build/html
 description =
   Set up a server to directly preview changes to the HTML pages


### PR DESCRIPTION
- Shortens the URLs, see https://github.com/ComPWA/policy/issues/158